### PR TITLE
Add Nix flake support for reproducible development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ dkms.conf
 
 # debug information files
 *.dwo
+
+# Nix
+.direnv/
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Supports downloading songs directly from **YouTube Music**, MP3/WAV/OGG/FLAC pla
 
 ## Build
 
+### Using Nix (Recommended for Linux)
+
+```bash
+git clone https://github.com/ZachVFXX/SaturnPlayer.git
+cd SaturnPlayer
+nix develop  # or use direnv
+cd src && make -f Makefile.lin release
+./main_release ~/Music/
+```
+
+### Manual Build
+
 Requirements:
 
 * C compiler (gcc / clang)
@@ -37,6 +49,8 @@ Requirements:
 * FFmpeg development libraries
 * raylib
 * yt-dlp downloaded and set in path with deno and ffmpeg to path (needed for yt-dlp to fetch and download properly, see the yt-dlp wiki for more info)
+
+#### Linux
 
 On Linux, it use pkg_config. Install the dependencies using your package manager:
 ffmpeg-dev
@@ -50,6 +64,7 @@ cd SaturnPlayer/src/
 make -f Makefile.lin release && ./main_release ~/musics_folders/
 ```
 
+#### Windows
 
 On Windows, download the ffmpeg and freetype source code and use the ffmpeg_build.txt and freetype.txt command to build the require 
 dependencies.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "SaturnPlayer development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              gcc
+              clang
+              gnumake
+              pkg-config
+              ffmpeg
+              raylib
+              freetype
+              fontconfig
+              yt-dlp
+              deno
+            ];
+          };
+        });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    gcc
+    clang
+    gnumake
+    pkg-config
+    ffmpeg
+    raylib
+    freetype
+    fontconfig
+    yt-dlp
+    deno
+  ];
+}

--- a/src/Makefile.lin
+++ b/src/Makefile.lin
@@ -14,10 +14,16 @@ FREETYPE_LIBS   = $(shell $(PKG_CONFIG) --libs freetype2)
 
 FONTCONFIG_LIBS = $(shell $(PKG_CONFIG) --libs fontconfig)
 
-LINKRAYLIB = -I/usr/local/include -L../raylib/src -lraylib -lGL -lX11 -lm -lpthread -ldl -lrt
+RAYLIB_CFLAGS = $(shell $(PKG_CONFIG) --cflags raylib 2>/dev/null)
+RAYLIB_LIBS = $(shell $(PKG_CONFIG) --libs raylib 2>/dev/null)
 
-ALL_CFLAGS = $(CFLAGS) $(FFMPEG_CFLAGS) $(FREETYPE_CFLAGS)
-ALL_LIBS   = $(LINKRAYLIB) $(FFMPEG_LIBS) $(FREETYPE_LIBS) $(FONTCONFIG_LIBS)
+ifeq ($(strip $(RAYLIB_LIBS)),)
+RAYLIB_CFLAGS = -I/usr/local/include
+RAYLIB_LIBS = -L../raylib/src -lraylib -lGL -lX11 -lm -lpthread -ldl -lrt
+endif
+
+ALL_CFLAGS = $(CFLAGS) $(FFMPEG_CFLAGS) $(FREETYPE_CFLAGS) $(RAYLIB_CFLAGS)
+ALL_LIBS   = $(RAYLIB_LIBS) $(FFMPEG_LIBS) $(FREETYPE_LIBS) $(FONTCONFIG_LIBS) -lm
 
 debug: main
 all: main packer
@@ -36,10 +42,10 @@ main.o: main.c
 	$(CC) $(ALL_CFLAGS) $(CDEBUGFLAGS) -c $< -o $@
 
 packer: packer.o
-	$(CC) $(CDEBUGFLAGS) -o $@ $^ $(LINKRAYLIB)
+	$(CC) $(CDEBUGFLAGS) -o $@ $^ $(RAYLIB_LIBS)
 
 packer.o: packer.c
-	$(CC) $(CFLAGS) $(CDEBUGFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(RAYLIB_CFLAGS) $(CDEBUGFLAGS) -c $< -o $@
 
 clean:
 	rm -f main main_release packer *.o

--- a/src/core/audio_raylib.c
+++ b/src/core/audio_raylib.c
@@ -1,5 +1,5 @@
 #include "audio_backend.h"
-#include "../../raylib/include/raylib.h"
+#include <raylib.h>
 #include <stdlib.h>
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -10,8 +10,8 @@
 
 #include "core/core.h"
 #include "core/queue.h"
-#include "../raylib/include/raylib.h"
-#include "../raylib/include/raymath.h"
+#include <raylib.h>
+#include <raymath.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1,5 +1,5 @@
 #include <libavformat/avformat.h>
-#include "../raylib/include/raylib.h"
+#include <raylib.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>

--- a/src/multi_font/multi_font_unix.c
+++ b/src/multi_font/multi_font_unix.c
@@ -1,5 +1,5 @@
 
-#include "../../freetype/include/ft2build.h"
+#include <ft2build.h>
 #include FT_FREETYPE_H
 #include <fontconfig/fontconfig.h>
 
@@ -7,7 +7,7 @@
 #include <string.h>
 #include "stdint.h"
 #include "stdbool.h"
-#include "../../raylib/include/raylib.h"
+#include <raylib.h>
 
 #define ATLAS_SIZE 4096
 #define GLYPH_PAD  2

--- a/src/multi_font/multi_font_win.c
+++ b/src/multi_font/multi_font_win.c
@@ -1,4 +1,4 @@
-#include "../../freetype_build/include/ft2build.h"
+#include <ft2build.h>
 #include FT_FREETYPE_H
 
 #include <windows.h>
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include "../../raylib/include/raylib.h"
+#include <raylib.h>
 
 #include <ctype.h>
 


### PR DESCRIPTION
- Add flake.nix with all required dependencies (FFmpeg, raylib, freetype, etc.)
- Add shell.nix for legacy nix-shell support
- Add .envrc for direnv integration
- Update Makefile.lin to use pkg-config for raylib with fallback
- Update source files to use system raylib headers instead of relative paths
- Update .gitignore to exclude Nix build artifacts
- Update README with Nix build instructions